### PR TITLE
Fix for mount_point location check in resource provider

### DIFF
--- a/resources/logical_volume.rb
+++ b/resources/logical_volume.rb
@@ -30,7 +30,7 @@ attribute :mount_point, :kind_of => [ Hash, String], :callbacks => {
         value.class == String || ( value[:location] && !value[:location].empty? )
     end,
     ': location must be an absolute path!' => Proc.new do |value| 
-        matches = value[:location] =~ %r{^/[^\0]*} ||  value =~ %r{^/[^\0]*}
+        matches = value =~ %r{^/[^\0]*} || value[:location] =~ %r{^/[^\0]*}
         !matches.nil?
     end 
 }


### PR DESCRIPTION
When using a string as mount_point the check breaks with a can't convert symbol to integer.
The check for the string location needs to come before the check for the hash location.
