### PR TITLE
[COOK-2992] Add resize support for logical and physical volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Manages LVM physical volumes.
 ### Actions
 
 - `:create` - Creates a new physical volume. Default.
+- `:resize` - Resizes a existing physical volume to the block device size in case it was extended.
 
 ### Attribute Parameters
 
@@ -52,6 +53,8 @@ Manages LVM logical volumes
   supported by LVM&mdash;SI bytes (e.g. 10G), physical extents, or percentages
   of all the extents in the volume group, all the free extents, or of the
   physical volumes assigned to the volume.
+- `resize` - When resize is true and the requested volume is already existing
+  and smaller than the requested size the volume is instead extended to the desired size.
 - `filesystem` - The filesystem to format the volume as. The appropriate tools
   must be installed for the filesystem.
 - `mount_point` - Either a string containing the path to the mount point, or a

--- a/providers/logical_volume.rb
+++ b/providers/logical_volume.rb
@@ -15,6 +15,100 @@ action :create do
     device_name = "/dev/mapper/#{to_dm_name(new_resource.group)}-#{to_dm_name(new_resource.name)}"
     fs_type = new_resource.filesystem
 
+    ruby_block "resize physical volumes for lv #{new_resource.name}" do
+      lvm = LVM::LVM.new
+      block do
+        lvm.physical_volumes.each { |pv|
+          Chef::Log.debug "Resizing physical volume #{pv.name}"
+          lvm.raw "pvresize #{pv.name}"
+        }
+      end
+      not_if do
+        lvm = LVM::LVM.new
+        lvm.physical_volumes.nil? or not new_resource.resize
+      end
+    end
+
+    ruby_block "extend_logical_volume_#{new_resource.name}" do
+      block do
+        lvm = LVM::LVM.new
+
+        vg = lvm.volume_groups[new_resource.group]
+        if vg.nil?
+          Chef::Application.fatal!("Error volume group #{new_resource.group} does not exist", 2 )
+        else
+          lv = vg.logical_volumes.select do |lvs|
+            lvs.name == new_resource.name
+          end
+          Chef::Application.fatal!("Error logical volume #{new_resource.name} does not exist", 2 ) if lv.empty?
+        end
+
+        lv = lv.first
+        pe_size = lvm.volume_groups[new_resource.group].extent_size.to_i
+        pe_free = lvm.volume_groups[new_resource.group].free_count.to_i
+        lv_size_cur = lv.size.to_i / pe_size
+
+        group = new_resource.group
+
+        lv_size_req = case new_resource.size
+                        when /(\d+)k/
+                          ($1.to_i *1024) / pe_size
+                        when /(\d+)K/
+                          ($1.to_i * 1000) / pe_size
+                        when /(\d+)m/
+                          ($1.to_i * 1048576) / pe_size
+                        when /(\d+)M/
+                          ($1.to_i * 1000000) / pe_size
+                        when /(\d+)g/
+                          ($1.to_i * 1073741824) / pe_size
+                        when /(\d+)G/
+                          ($1.to_i * 1000000000) / pe_size
+                        when /(\d+)t/
+                          ($1.to_i * 1099511627776) / pe_size
+                        when /(\d+)T/
+                          ($1.to_i * 1000000000000) / pe_size
+                        when /(\d+)/
+                          $1.to_i
+                      end
+
+        Chef::Log.debug "Resizing logical volume #{lv.name} from #{lv_size_cur} pe to #{lv_size_req} pe with #{pe_free} pe left in volume group #{group}"
+
+        Chef::Application.fatal!("Error trying to extend logical volume #{lv.name} beyond the capacity of volume group #{group}", 2 ) if ( lv_size_req - lv_size_cur ) > pe_free
+
+        if lv_size_cur >= lv_size_req
+
+          Chef::Log.debug "Logical volume #{lv.name} in volume group #{group} already at requested size"
+
+        else
+
+          resize_fs = "--resizefs"
+          stripes = new_resource.stripes ? "--stripes #{new_resource.stripes}" : ''
+          stripe_size = new_resource.stripe_size ? "--stripesize #{new_resource.stripe_size}" : ''
+          mirrors = new_resource.mirrors ? "--mirrors #{new_resource.mirrors}" : ''
+
+          command = "lvextend -l #{lv_size_req} #{resize_fs} #{stripes} #{stripe_size} #{mirrors} #{lv.path} "
+          Chef::Log.debug "Running command: #{command}"
+          output = lvm.raw command
+          Chef::Log.debug "Command output: #{output}"
+
+          new_resource.updated_by_last_action true
+
+        end
+      end
+      not_if do
+        lvm = LVM::LVM.new
+        vg = lvm.volume_groups[new_resource.group]
+        if vg.nil?
+          true
+        else
+          found_lvs = vg.logical_volumes.select do |lv|
+            lv.name == new_resource.name
+          end
+          found_lvs.empty? or not new_resource.resize
+        end
+      end
+    end
+
     ruby_block "create_logical_volume_#{new_resource.name}" do
         block do 
             lvm = LVM::LVM.new

--- a/providers/physical_volume.rb
+++ b/providers/physical_volume.rb
@@ -12,3 +12,13 @@ action :create do
         only_if { @lvm.physical_volumes[new_resource.name].nil? }
     end
 end
+
+action :resize do
+    ruby_block "resize physical volume on #{new_resource.name}" do
+      @lvm = LVM::LVM.new
+      block do
+        @lvm.raw "pvresize #{new_resource.name}"
+      end
+      not_if @lvm.physical_volumes[new_resource.name].nil?
+    end
+end

--- a/resources/logical_volume.rb
+++ b/resources/logical_volume.rb
@@ -24,6 +24,7 @@ attribute :name,
     }
 attribute :group, :kind_of => String
 attribute :size, :kind_of => String, :regex => /\d+[kKmMgGtT]|(\d{2}|100)%(FREE|VG|PVS)|\d+/, :required => true
+attribute :resize, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :filesystem, :kind_of => String
 attribute :mount_point, :kind_of => [ Hash, String], :callbacks => {
     ': location is required!' => Proc.new do |value| 
@@ -44,3 +45,5 @@ attribute :stripe_size, :kind_of => Integer, :callbacks => {
 attribute :mirrors, :kind_of => Integer, :callbacks => must_be_greater_than_0
 attribute :contiguous, :kind_of => [TrueClass, FalseClass]
 attribute :readahead, :kind_of => [ Integer, String ], :equal_to => [ 2..120, 'auto', 'none' ].flatten!
+
+actions :create

--- a/resources/physical_volume.rb
+++ b/resources/physical_volume.rb
@@ -4,4 +4,4 @@ def initialize *args
 end
 
 attribute :name, :kind_of => String, :name_attribute => true, :required => true
-actions :create
+actions :create, :resize


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2992

The logical volume lwrp was enhanced to support resizing existing logical volumes. If the resize is set to true in the resource and the lvm is already existing and smaller than the requested size it will be extended to the desired size. The physical volume lwrp is extended with a resize action which will resize the pv to the current size of the underlying block device. Intended for use with online disk extend in virtual environments.
