### PR TITLE
[COOK-4012]: Adds :enable parameter for mount to allow skipping of fstab entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Manages LVM logical volumes.
       <ul>
         <li><tt>location<tt> - (required) the directory to mount the volume on</li>
         <li><tt>options</tt> - the mount options for the volume</li>
+        <li><tt>enable</tt> - whether to create the fstab entry</li>
         <li><tt>dump</tt> - the <tt>dump</tt> field for the fstab entry</li>
         <li><tt>pass</tt> - the <tt>pass</tt> field for the fstab entry</li>
       </ul>

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -115,7 +115,13 @@ class Chef
             action :nothing
           end
           mount_resource.run_action(:mount)
-          mount_resource.run_action(:enable)
+          # We should enable by default to remain backwards-compatible, as we used to enable without asking
+          mount_spec[:enable] ||= true
+          if mount_spec[:enable]
+            mount_resource.run_action(:enable)
+          else
+            mount_resource.run_action(:disable)
+          end
           # Mark the resource as updated if the mount resource is updated
           new_resource.updated_by_last_action(mount_resource.updated?)
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs lvm2 package'
-version           '1.0.1'
+version           '1.0.2'
 
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
Default action is still to enable, but we allow this to be skipped.
