### PR TITLE
[COOK-4408] - Update mountpoint perms to 0755

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -95,7 +95,7 @@ class Chef
 
           # Create the mount point
           dir_resource = directory mount_spec[:location] do
-            mode 0777
+            mode 0755
             owner 'root'
             group 'root'
             recursive true


### PR DESCRIPTION
Mountpoint perms are currently set to read/write/execute for everyone.  Setting
the perms to a slighly more strict 0755.  This will prevent everyone from
being able to write to the mountpoint dir if there is not a mount on top of it.

https://tickets.opscode.com/browse/COOK-4408
