### PR TITLE
[COOK-4486] - Add ChefSpec matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: lvm
-# Library:: provider_lvm_volume_group
+# Library:: matchers
 #
 # Copyright 2014, Opscode, Inc.
 #


### PR DESCRIPTION
- Add create_lvm_logical_volume, nothing_lvm_logical_volume (since
  logical_volume can be a sub-resource of lvm_volume_group),
  create_lvm_physical_volume, and create_lvm_volume_group ChefSpec
  matchers.
- This is for https://tickets.opscode.com/browse/COOK-4486.
