### PR TITLE
Enable the logical volume it if was disabled

### DIFF
--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -73,7 +73,7 @@ class Chef
           updates << true
         else
           lv = vg.logical_volumes.select { |lv| lv.name == name }.first
-          if lv.state.to_sym == :active
+          if !lv.state.nil? && lv.state.to_sym == :active
             Chef::Log.info "Logical volume '#{name}' already exists and active. Not creating..."
           else
             Chef::Log.info "Logical volume '#{name}' already created and inactive. Activating now..."


### PR DESCRIPTION
When restoring block devices from backups (volume snapshots), on
CentOS, the logical volumes are deactivated by default. This
change will enable/activate the logical volume if it was
deactivated.
