### PR TITLE
[#217] Fix `pvcreate` and `lvcreate` not to wait for interactive input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the lvm cookbook.
 
 ## Unreleased
 
+- Fix `pvcreate` and `lvcreate` to return an error if a valid signature was found on the device instead of waiting interactivly for confirmation.
+
 ## 6.0.2 - *2022-08-07*
 
 - CI: Remove use of Vagrant boxes from OSUOSL

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -317,7 +317,7 @@ class Chef
         mirrors = new_resource.mirrors ? "--mirrors #{new_resource.mirrors}" : ''
         contiguous = new_resource.contiguous ? '--contiguous y' : ''
         readahead = new_resource.readahead ? "--readahead #{new_resource.readahead}" : ''
-        yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
+        yes_flag = new_resource.wipe_signatures == true ? '--yes' : '-qq'
         lv_params = new_resource.lv_params
         name = new_resource.name
         group = new_resource.group

--- a/libraries/provider_lvm_volume_group.rb
+++ b/libraries/provider_lvm_volume_group.rb
@@ -129,7 +129,7 @@ class Chef
         else
           physical_volumes = physical_volume_list.join(' ')
           physical_extent_size = new_resource.physical_extent_size ? "-s #{new_resource.physical_extent_size}" : ''
-          yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
+          yes_flag = new_resource.wipe_signatures == true ? '--yes' : '-qq'
           command = "vgcreate #{name} #{physical_extent_size} #{physical_volumes} #{yes_flag}"
           Chef::Log.debug "Executing lvm command: '#{command}'"
           output = lvm.raw command

--- a/resources/physical_volume.rb
+++ b/resources/physical_volume.rb
@@ -18,7 +18,7 @@ action :create do
   require_lvm_gems
   lvm = LVM::LVM.new(lvm_options)
   if lvm.physical_volumes[new_resource.name].nil?
-    yes_flag = new_resource.wipe_signatures == true ? '--yes' : ''
+    yes_flag = new_resource.wipe_signatures == true ? '--yes' : '-qq'
 
     converge_by("creating physical volume '#{new_resource.name}'") do
       lvm.raw "pvcreate #{new_resource.name} #{yes_flag}"


### PR DESCRIPTION
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>

# Description

`pvcreate` and `lvcreate` wait for interactive input when the `wipe_signatures` property is not set. This PR changes their behavior to bail out immediately with an error message.

## Issues Resolved

 * #217

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] ~~New functionality includes testing.~~ not applicable
- [ ] ~~New functionality has been documented in the README if applicable.~~ not applicable
