### PR TITLE
Update chef-ruby-lvm-attrib gem to 0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the lvm cookbook.
 
 ## Unreleased
 
+- Update chef-ruby-lvm-attrib gem to 0.3.11
+
 ## 6.1.1 - *2022-09-29*
 
 - Fix parsing of output from `blkid` in `libraries/provider_lvm_logical_volume.rb` due to different behavior under busybox (e.g., running in hab effortless)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.10'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.11'
 default['lvm']['rubysource'] = Chef::Config['rubygems_url']


### PR DESCRIPTION
chef-ruby-lvm-attrib 0.3.10 was yanked from rubygems.out

Obvious fix.

Signed-off-by: ryanwoodsmall <rwoodsmall@gmail.com>

# Description

**chef-ruby-lvm-attrib** version 0.3.10 was yanked upstream: https://rubygems.org/gems/chef-ruby-lvm-attrib/versions/0.3.10

This boke a number of builds for cookbooks. Bump the version to the 0.3.11, which is currently latest available.

## Issues Resolved

No issue submitted

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [-] New functionality includes testing.
- [-] New functionality has been documented in the README if applicable.
