### PR TITLE
Update chef-ruby-lvm-attrib gem to 0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the lvm cookbook.
 
 ## Unreleased
 
+- Update chef-ruby-lvm-attrib gem to 0.3.14
+
 ## 6.1.16 - *2023-10-03*
 
 ## 6.1.15 - *2023-09-29*

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.11'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.14'
 default['lvm']['rubysource'] = Chef::Config['rubygems_url']


### PR DESCRIPTION
# Description

Update chef-ruby-lvm-attrib gem to 0.3.14

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
