### PR TITLE
Update chef-ruby-lvm-attrib gem to 0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the lvm cookbook.
 
 ## Unreleased
 
+- Update chef-ruby-lvm-attrib gem to 0.3.15
+
 ## 6.1.17 - *2023-11-01*
 
 - Update chef-ruby-lvm-attrib gem to 0.3.14

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.14'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.3.15'
 default['lvm']['rubysource'] = Chef::Config['rubygems_url']


### PR DESCRIPTION
# Description

Update chef-ruby-lvm-attrib gem to 0.3.15
## Issues Resolved

Unable to load lvm attributes [lvs.yaml] for version [2.03.22(2)]

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
