### PR TITLE
Bump lvm attrib gem, add debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # lvm Cookbook CHANGELOG
 
+## Unreleased
+
+- Bump gem to 0.4.5
+
 This file is used to list changes made in each version of the lvm cookbook.
 
 Standardise files with files in sous-chefs/repo-management

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 #
 
 default['lvm']['chef-ruby-lvm']['version'] = '0.4.0'
-default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.4.2'
+default['lvm']['chef-ruby-lvm-attrib']['version'] = '0.4.5'
 default['lvm']['rubysource'] = Chef::Config['rubygems_url']

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,6 +19,7 @@ platforms:
   - name: centos-stream-9
   - name: debian-11
   - name: debian-12
+  - name: debian-13
   - name: fedora-latest
   - name: opensuse-leap-15
   - name: rockylinux-8


### PR DESCRIPTION
# Description

Bump the version to support debian trixie.

## Issues Resolved

https://github.com/sous-chefs/lvm/issues/277

## Check List

- [x] A [conventional commit](https://www.conventionalcommits.org/) message
  This triggers our CHANGELOG and release pipeline (release-please); without your change, it cannot be released.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
