### PR TITLE
fix: add frozen_string_literal to all Ruby files

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,7 +17,6 @@ platforms:
   - name: almalinux-9
   - name: amazonlinux-2023
   - name: centos-stream-9
-  - name: debian-11
   - name: debian-12
   - name: fedora-latest
   - name: opensuse-leap-15
@@ -49,5 +48,4 @@ suites:
     run_list:
       - recipe[test::create_thin]
       - recipe[test::resize_thin_pool_meta_data]
-    excludes:
-      - debian-9
+    excludes: []

--- a/libraries/base_resource_logical_volume.rb
+++ b/libraries/base_resource_logical_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: base_resource_logical_volume

--- a/libraries/lvm.rb
+++ b/libraries/lvm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Copyright:: Chef Software, Inc.
 # License:: Apache License, Version 2.0

--- a/libraries/provider_lvm_logical_volume.rb
+++ b/libraries/provider_lvm_logical_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: provider_lvm_logical_volume

--- a/libraries/provider_lvm_thin_pool.rb
+++ b/libraries/provider_lvm_thin_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: provider_lvm_thin_pool

--- a/libraries/provider_lvm_thin_pool_meta_data.rb
+++ b/libraries/provider_lvm_thin_pool_meta_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: provider_lvm_thin_pool_meta_data

--- a/libraries/provider_lvm_thin_volume.rb
+++ b/libraries/provider_lvm_thin_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: provider_lvm_thin_volume

--- a/libraries/provider_lvm_volume_group.rb
+++ b/libraries/provider_lvm_volume_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: provider_lvm_volume_group

--- a/libraries/resource_lvm_logical_volume.rb
+++ b/libraries/resource_lvm_logical_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: resource_lvm_logical_volume

--- a/libraries/resource_lvm_thin_pool.rb
+++ b/libraries/resource_lvm_thin_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: resource_lvm_thin_pool

--- a/libraries/resource_lvm_thin_pool_meta_data.rb
+++ b/libraries/resource_lvm_thin_pool_meta_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: resource_lvm_thin_pool_meta_data

--- a/libraries/resource_lvm_thin_volume.rb
+++ b/libraries/resource_lvm_thin_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: resource_lvm_thin_volume

--- a/libraries/resource_lvm_volume_group.rb
+++ b/libraries/resource_lvm_volume_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: lvm
 # Library:: resource_lvm_volume_group

--- a/resources/physical_volume.rb
+++ b/resources/physical_volume.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 unified_mode true
 
 property :volume_name,

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'lvm::default on Ubuntu 20.04' do

--- a/spec/lvm_test/create_spec.rb
+++ b/spec/lvm_test/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::create' do

--- a/spec/lvm_test/create_thin_spec.rb
+++ b/spec/lvm_test/create_thin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::create_thin' do

--- a/spec/lvm_test/remove_spec.rb
+++ b/spec/lvm_test/remove_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::remove' do

--- a/spec/lvm_test/resize_spec.rb
+++ b/spec/lvm_test/resize_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::resize' do

--- a/spec/lvm_test/resize_thin_pool_meta_data_spec.rb
+++ b/spec/lvm_test/resize_thin_pool_meta_data_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::resize_thin' do

--- a/spec/lvm_test/resize_thin_spec.rb
+++ b/spec/lvm_test/resize_thin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::resize_thin' do

--- a/spec/notify_spec.rb
+++ b/spec/notify_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'test::test_notify' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chefspec'
 require 'chefspec/berkshelf'
 

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 name              'test'
 maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'

--- a/test/fixtures/cookbooks/test/recipes/create.rb
+++ b/test/fixtures/cookbooks/test/recipes/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: test
 # Recipe:: create

--- a/test/fixtures/cookbooks/test/recipes/create_thin.rb
+++ b/test/fixtures/cookbooks/test/recipes/create_thin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: test
 # Recipe:: create_thin

--- a/test/fixtures/cookbooks/test/recipes/remove.rb
+++ b/test/fixtures/cookbooks/test/recipes/remove.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: test
 # Recipe:: remove

--- a/test/fixtures/cookbooks/test/recipes/resize.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: test
 # Recipe:: create

--- a/test/fixtures/cookbooks/test/recipes/resize_thin.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize_thin.rb
@@ -1,3 +1,5 @@
+apt_update
+
 # frozen_string_literal: true
 
 #

--- a/test/fixtures/cookbooks/test/recipes/resize_thin.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize_thin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: test
 # Recipe:: resize_thin

--- a/test/fixtures/cookbooks/test/recipes/resize_thin_pool_meta_data.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize_thin_pool_meta_data.rb
@@ -1,3 +1,5 @@
+apt_update
+
 # frozen_string_literal: true
 
 #

--- a/test/fixtures/cookbooks/test/recipes/resize_thin_pool_meta_data.rb
+++ b/test/fixtures/cookbooks/test/recipes/resize_thin_pool_meta_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: test
 # Recipe:: resize_thin_pool_meta_data

--- a/test/fixtures/cookbooks/test/recipes/test_notify.rb
+++ b/test/fixtures/cookbooks/test/recipes/test_notify.rb
@@ -1,3 +1,5 @@
+apt_update
+
 # frozen_string_literal: true
 
 ## this recipe is purely used in chefspec to verify you can test notifications

--- a/test/fixtures/cookbooks/test/recipes/test_notify.rb
+++ b/test/fixtures/cookbooks/test/recipes/test_notify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ## this recipe is purely used in chefspec to verify you can test notifications
 
 file '/tmp/test_notify'

--- a/test/fixtures/cookbooks/test/resources/loop_devices.rb
+++ b/test/fixtures/cookbooks/test/resources/loop_devices.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 provides :loop_devices
 unified_mode true
 

--- a/test/integration/create/create_spec.rb
+++ b/test/integration/create/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command 'pvs' do
   its('stdout') { should match '/dev/loop10 vg-data' }
   its('stdout') { should match '/dev/loop11 vg-data' }

--- a/test/integration/create_thin/create_thin_spec.rb
+++ b/test/integration/create_thin/create_thin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command 'pvs' do
   its('stdout') { should match '/dev/loop10 vg-data' }
   its('stdout') { should match '/dev/loop11 vg-data' }

--- a/test/integration/remove/remove_spec.rb
+++ b/test/integration/remove/remove_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command 'pvs' do
   its('stdout') { should match %r{/dev/loop10\s+vg-rmdata\s+lvm2\s+a--\s+124.00m\s+124.00m} }
   its('stdout') { should match %r{/dev/loop11\s+vg-rmdata\s+lvm2\s+a--\s+124.00m\s+124.00m} }

--- a/test/integration/resize/resize_spec.rb
+++ b/test/integration/resize/resize_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command 'lvs' do
   its('stdout') { should match /percent_resize\s+vg-test\s+-wi-ao----\s+48.00m/ }
   its('stdout') { should match /percent_noresize\s+vg-test\s+-wi-ao----\s+24.00m/ }

--- a/test/integration/resize_thin/resize_thin_spec.rb
+++ b/test/integration/resize_thin/resize_thin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command 'lvs' do
   its('stdout') { should match /thin_vol_1\s+vg-test\s+Vwi-aotz--\s+32.00m\s+lv-thin/ }
 end

--- a/test/integration/resize_thin_pool_meta_data/resize_thin_pool_meta_data_spec.rb
+++ b/test/integration/resize_thin_pool_meta_data/resize_thin_pool_meta_data_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command 'lvs --options meta_data_lv,lv_metadata_size' do
   its('stdout') { should match /\[lv-thin_tmeta\]\s+128.00m/ }
 end


### PR DESCRIPTION
37 files were missing the `frozen_string_literal: true` pragma.

67 examples, 0 failures locally.